### PR TITLE
rendered graph does not fit entirely within its SVG element?

### DIFF
--- a/src/graph/Graph.js
+++ b/src/graph/Graph.js
@@ -182,7 +182,7 @@ Graph.prototype.resize = function(xmin, xmax, ymin, ymax) {
 	var cx = self.g.node().parentNode.parentNode.clientWidth;
 	//somewhere around here I think we need to subtract the height of the FragKey?
 	// ...the graph is not fitting entirely within its SVG element
-	var fragKeyHeight = 400;//can tidy this up somehow 
+	var fragKeyHeight = 100;//can tidy this up somehow 
 	var cy = self.g.node().parentNode.parentNode.clientHeight - fragKeyHeight;
 	
 	self.g.attr("width", cx).attr("height", cy);

--- a/src/graph/Graph.js
+++ b/src/graph/Graph.js
@@ -180,7 +180,10 @@ Graph.prototype.resize = function(xmin, xmax, ymin, ymax) {
 	var self = this;
 	//see https://gist.github.com/mbostock/3019563
 	var cx = self.g.node().parentNode.parentNode.clientWidth;
-	var cy = self.g.node().parentNode.parentNode.clientHeight;
+	//somewhere around here I think we need to subtract the height of the FragKey?
+	// ...the graph is not fitting entirely within its SVG element
+	var fragKeyHeight = 400;//can tidy this up somehow 
+	var cy = self.g.node().parentNode.parentNode.clientHeight - fragKeyHeight;
 	
 	self.g.attr("width", cx).attr("height", cy);
 	var width = cx - self.margin.left - self.margin.right;


### PR DESCRIPTION
I think the drawn graph does not fit entirely within its SVG element?
There some comment and a hacky fix in this pull request
